### PR TITLE
Feature/#73 user profile page

### DIFF
--- a/lib/app_route.dart
+++ b/lib/app_route.dart
@@ -1,6 +1,7 @@
 class AppRoute {
   static const String home = '/';
   static const String pinDetail = '/pin_detail';
+  static const String userDetail = '/user_detail';
   static const String inputUrl = '/input_url';
   static const String crawlingImage = '/crawling_image';
   static const String loginTop = '/login_top';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:pintersest_clone/view/authentication//login_widget/login_widget.
 import 'package:pintersest_clone/view/main/main_navigation_page.dart';
 import 'package:pintersest_clone/view/main/pin_detail_widget/pin_detail_widget.dart';
 import 'package:pintersest_clone/view/main/select_board_widget/select_board_widget.dart';
+import 'package:pintersest_clone/view/main/user_detail_widget/user_detail_widget.dart';
 
 import 'api/api_client.dart';
 import 'data/image_repository.dart';
@@ -47,6 +48,7 @@ class MyApp extends StatelessWidget {
           routes: {
             AppRoute.home: (context) => MainNavigationPage(),
             AppRoute.pinDetail: (context) => PinDetailWidget(),
+            AppRoute.userDetail: (context) => UserDetailWidget(),
             AppRoute.inputUrl: (context) => InputUrlWidget(),
             AppRoute.crawlingImage: (context) => CrawlingImageWidget(),
             AppRoute.loginTop: (context) => LoginTopWidget(),

--- a/lib/view/main/account_widget/account_widget.dart
+++ b/lib/view/main/account_widget/account_widget.dart
@@ -7,12 +7,26 @@ import 'package:image_picker/image_picker.dart';
 import 'package:pintersest_clone/app_route.dart';
 import 'package:pintersest_clone/data/pins_repository.dart';
 import 'package:pintersest_clone/model/pin_model.dart';
+import 'package:pintersest_clone/model/user_model.dart';
 import 'package:pintersest_clone/values/app_colors.dart';
 import 'package:pintersest_clone/view/main/create_pin_widget/create_pin_widget.dart';
 import 'package:pintersest_clone/view/main/home_widget/bloc/home_bloc.dart';
 import 'package:pintersest_clone/view/main/home_widget/bloc/home_event.dart';
 import 'package:pintersest_clone/view/main/home_widget/bloc/home_state.dart';
 import 'package:pintersest_clone/view/main/pin_detail_widget/pin_detail_widget.dart';
+import 'package:pintersest_clone/view/main/user_detail_widget/user_detail_widget.dart';
+
+// 詳細画面に渡すためのサンプルデータです
+final UserModel sampleUser = UserModel(
+    id: 'mrypq',
+    firstName: 'めろ子',
+    lastName: 'めろ田',
+    profileImageUrl:
+        'https://bucket-pinterest-001.s3-ap-northeast-1.amazonaws.com/sample/profile_image.jpeg',
+    description: 'めろぴっぴです',
+    location: 'めろ王国',
+    web: 'https://github.com/mrypq',
+    createdAt: DateTime.parse('2020-01-01T10:10:10Z'));
 
 class AccountWidget extends StatefulWidget {
   @override
@@ -60,7 +74,10 @@ class _AccountWidgetState extends State<AccountWidget> {
           elevation: 0,
           backgroundColor: Colors.white,
           leading: GestureDetector(
-            onTap: () {},
+            onTap: () {
+              Navigator.pushNamed(context, AppRoute.userDetail,
+                  arguments: UserDetailWidgetArguments(sampleUser));
+            },
             child: Container(
               padding: const EdgeInsets.all(8),
               child: const CircleAvatar(

--- a/lib/view/main/account_widget/account_widget.dart
+++ b/lib/view/main/account_widget/account_widget.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:pintersest_clone/app_route.dart';
 import 'package:pintersest_clone/data/pins_repository.dart';
 import 'package:pintersest_clone/model/pin_model.dart';
+import 'package:pintersest_clone/values/app_colors.dart';
 import 'package:pintersest_clone/view/main/create_pin_widget/create_pin_widget.dart';
 import 'package:pintersest_clone/view/main/home_widget/bloc/home_bloc.dart';
 import 'package:pintersest_clone/view/main/home_widget/bloc/home_event.dart';
@@ -50,21 +51,32 @@ class _AccountWidgetState extends State<AccountWidget> {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
-        appBar: PreferredSize(
-          preferredSize: Size.fromHeight(_topNavigationBarHeight),
-          child: AppBar(
-            brightness: Brightness.light,
-            elevation: 0,
-            backgroundColor: Colors.white,
-            bottom: TabBar(
-              indicatorColor: Colors.black87,
-              labelColor: Colors.black87,
-              labelStyle: const TextStyle(fontSize: 10),
-              tabs: <Widget>[
-                const Tab(text: 'ボード'),
-                const Tab(text: 'ピン'),
-              ],
+        appBar: AppBar(
+          title: const Text(
+            'アカウント',
+            style: TextStyle(color: AppColors.black),
+          ),
+          brightness: Brightness.light,
+          elevation: 0,
+          backgroundColor: Colors.white,
+          leading: GestureDetector(
+            onTap: () {},
+            child: Container(
+              padding: const EdgeInsets.all(8),
+              child: const CircleAvatar(
+                backgroundColor: AppColors.grey,
+                child: Text('TA'),
+              ),
             ),
+          ),
+          bottom: TabBar(
+            indicatorColor: Colors.black87,
+            labelColor: Colors.black87,
+            labelStyle: const TextStyle(fontSize: 10),
+            tabs: <Widget>[
+              const Tab(text: 'ボード'),
+              const Tab(text: 'ピン'),
+            ],
           ),
         ),
         body: TabBarView(

--- a/lib/view/main/user_detail_widget/user_detail_widget.dart
+++ b/lib/view/main/user_detail_widget/user_detail_widget.dart
@@ -1,8 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:pintersest_clone/model/user_model.dart';
+
+class UserDetailWidgetArguments {
+  UserDetailWidgetArguments(this.user);
+
+  final UserModel user;
+}
 
 class UserDetailWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container();
+    final args =
+        ModalRoute.of(context).settings.arguments as UserDetailWidgetArguments;
+    return Scaffold(
+      body: Container(),
+    );
   }
 }

--- a/lib/view/main/user_detail_widget/user_detail_widget.dart
+++ b/lib/view/main/user_detail_widget/user_detail_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pintersest_clone/model/user_model.dart';
+import 'package:pintersest_clone/values/app_colors.dart';
 
 class UserDetailWidgetArguments {
   UserDetailWidgetArguments(this.user);
@@ -10,10 +11,82 @@ class UserDetailWidgetArguments {
 class UserDetailWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: _buildScreen(context),
+      ),
+    );
+  }
+
+  Widget _buildScreen(BuildContext context) {
     final args =
         ModalRoute.of(context).settings.arguments as UserDetailWidgetArguments;
-    return Scaffold(
-      body: Container(),
+    return Container(
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          IconButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              icon: Icon(Icons.arrow_back_ios)),
+          const SizedBox(height: 8),
+          _buildUserInfoView(args.user),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUserInfoView(UserModel user) {
+    return Center(
+      child: Column(
+        children: <Widget>[
+          CircleAvatar(
+            radius: 64,
+            backgroundImage:
+                Image.network(user.profileImageUrl, fit: BoxFit.cover).image,
+          ),
+          const SizedBox(height: 8),
+          Text(user.id,
+              style:
+                  const TextStyle(fontSize: 32, fontWeight: FontWeight.bold)),
+          _buildButtons()
+        ],
+      ),
+    );
+  }
+
+  Widget _buildButtons() {
+    return Container(
+      padding: const EdgeInsets.all(8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          IconButton(
+            onPressed: () {},
+            icon: Icon(Icons.share),
+          ),
+
+          FlatButton(
+            padding: const EdgeInsets.all(16),
+            onPressed: () {},
+            child: const Text('フォロー',
+                style: TextStyle(
+                    color: AppColors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold)),
+            color: AppColors.red,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(32),
+            ),
+          ),
+          IconButton(
+            onPressed: () {},
+            icon: Icon(Icons.more_horiz),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/main/user_detail_widget/user_detail_widget.dart
+++ b/lib/view/main/user_detail_widget/user_detail_widget.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class UserDetailWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}


### PR DESCRIPTION
close #73 

アカウントページにプロフィールアイコンを追加して、簡単なユーザー詳細画面を作りました。
本来の動きとは違いますが、今は遷移元がないので、このアイコンをタップするとサンプルデータのユーザー詳細画面にいくようになってます。
![Simulator Screen Shot - iPhone 11 Pro - 2020-06-22 at 17 18 36](https://user-images.githubusercontent.com/37692227/85265030-9aa37680-b4ac-11ea-97e8-560dfdbc52d1.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-06-22 at 17 17 48](https://user-images.githubusercontent.com/37692227/85265032-9d05d080-b4ac-11ea-83c0-ef9c3b47fe82.png)


