### PR TITLE
自分のピン一覧からピン詳細へ遷移する際のバグを修正

### DIFF
--- a/lib/view/main/board_detail/board_detail_widget.dart
+++ b/lib/view/main/board_detail/board_detail_widget.dart
@@ -52,8 +52,11 @@ class BoardDetailWidget extends StatelessWidget {
             crossAxisCount: 4,
             crossAxisSpacing: 8,
             mainAxisSpacing: 8,
-            itemBuilder: (context, index) =>
-                PinTile(pin: state.pins[index], heroTag: state.pins[index].id),
+            itemBuilder: (context, index) {
+              final heroTag = '${state.pins[index].id}-board';
+              return PinTile(
+                  pin: state.pins[index], heroTag: heroTag);
+            },
             staggeredTileBuilder: (index) => const StaggeredTile.fit(2),
             itemCount: state.pins.length);
       }

--- a/lib/view/main/home/home_widget.dart
+++ b/lib/view/main/home/home_widget.dart
@@ -84,8 +84,10 @@ class HomeWidget extends StatelessWidget {
             crossAxisCount: 4,
             crossAxisSpacing: 8,
             mainAxisSpacing: 8,
-            itemBuilder: (context, index) =>
-                PinTile(pin: pins[index], heroTag: pins[index].id),
+            itemBuilder: (context, index) {
+              final heroTag = '${pins[index].id}-home';
+              return PinTile(pin: pins[index], heroTag: heroTag);
+            },
             staggeredTileBuilder: (index) => const StaggeredTile.fit(2),
             itemCount: pins.length,
           ),

--- a/lib/view/main/pins_list/pins_list_widget.dart
+++ b/lib/view/main/pins_list/pins_list_widget.dart
@@ -78,8 +78,11 @@ class _PinsListWidgetState extends State<PinsListWidget> {
               crossAxisCount: 4,
               crossAxisSpacing: 8,
               mainAxisSpacing: 8,
-              itemBuilder: (context, index) =>
-                  PinTile(pin: pins[index], heroTag: pins[index].id),
+              itemBuilder: (context, index) {
+                final heroTag = '${pins[index].id}-account';
+                return PinTile(
+                    pin: pins[index], heroTag: heroTag);
+              },
               staggeredTileBuilder: (index) => const StaggeredTile.fit(2),
               itemCount: pins.length,
             ),


### PR DESCRIPTION
close #156 

heroTagはsubtree内で一意でなくてはならないようなので、pinのidの後ろにwidgetの名前をつけて対応しました。