### PR TITLE
カラーテーマの変更

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,6 +50,21 @@ class Pinterest extends StatelessWidget {
 
   final String initialRoute;
 
+  static const int _customPrimaryValue = 0xFFD91A40;
+  static const MaterialColor _customSwatch =
+      MaterialColor(_customPrimaryValue, <int, Color>{
+    50: Color(0xFFFAE4E8),
+    100: Color(0xFFF4BAC6),
+    200: Color(0xFFEC8DA0),
+    300: Color(0xFFE45F79),
+    400: Color(0xFFDF3C5D),
+    500: Color(_customPrimaryValue),
+    600: Color(0xFFD5173A),
+    700: Color(0xFFCF1332),
+    800: Color(0xFFCA0F2A),
+    900: Color(0xFFC0081C),
+  });
+
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
@@ -77,7 +92,7 @@ class Pinterest extends StatelessWidget {
         child: MaterialApp(
           title: 'Pinterest',
           theme: ThemeData(
-            primarySwatch: Colors.blue,
+            primarySwatch: _customSwatch,
             visualDensity: VisualDensity.adaptivePlatformDensity,
             splashFactory: const NoSplashFactory(),
           ),


### PR DESCRIPTION
カラーテーマを`D91A40`を基本としたマテリアルカラーに変更しました  
* indicator
* appbar（使ってないけど）
* Textfieldのいろんな色
とかの基本色がこのパレットの色になりまする  

例えば↓  
![スクリーンショット 2020-07-02 18 55 30](https://user-images.githubusercontent.com/59944509/86344747-9d188400-bc95-11ea-97f0-a2301cb765a8.png)  

今回のアプリのイメージカラー（暫定）↓  
![263A41-2D3333-D91A40-BAC8CE-E4E7EA](https://user-images.githubusercontent.com/59944509/86344453-4317be80-bc95-11ea-8242-e1ffb8a0604f.png)  

close #173 
